### PR TITLE
singularity pull from docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ To get the BIDSonym Docker image, you need to `install docker <https://docs.dock
 
 To get its Singularity version, you need to `install singularity <https://singularity.lbl.gov/all-releases>`_ and within the terminal of your choice type:
 
-:code:`singularity pull shub://PeerHerholz/BIDSonym`
+:code:`singularity pull docker://peerherholz/bidsonym`
 
 Documentation
 =============


### PR DESCRIPTION
Trying to do it from shub yields " While pulling shub image: error fetching image to cache: failed to get manifest for: shub://PeerHerholz/BIDSonym: the requested manifest was not found in singularity hub".  Doing it from Docker works.