### PR TITLE
Fix ignore flair t2w

### DIFF
--- a/bidsonym/run_deid.py
+++ b/bidsonym/run_deid.py
@@ -677,7 +677,7 @@ def run_deid():
         else:
             # Single-session or no-session processing
             process_subject_session(args, layout, subject_label,
-                                    session=None, log_print=log_print)
+                                    session_label=None, log_print=log_print)
         
         # Rename non-deidentified files with descriptive labels
         rename_non_deid(args.bids_dir, subject_label)

--- a/bidsonym/run_deid.py
+++ b/bidsonym/run_deid.py
@@ -154,8 +154,14 @@ def process_subject_session(args, layout, subject_label, session_label=None, log
     processed_modalities = ['T1w']  # T1w is always processed
     if args.deface_t2w:
         processed_modalities.append('T2w')
+    if "T2w" in args.modalities:
+        processed_modalities.append('T2w')
+        args.deface_t2w = True
     if args.deface_flair:
         processed_modalities.append('FLAIR')
+    if "FLAIR" in args.modalities:
+        processed_modalities.append('FLAIR')
+        args.deface_flair = True
     
     # Get T1w images for this subject/session
     if session_label:


### PR DESCRIPTION
The "modalities" CLI argument was ignored and therefore misleading.

Now, passing a modality name with --modalities should be fully equivalent to using the flags --deface_...